### PR TITLE
[build] fix build errors in pthreads test compile on Ubuntu with gcc-13

### DIFF
--- a/cmake/FindPthreads.cmake
+++ b/cmake/FindPthreads.cmake
@@ -59,12 +59,14 @@ MACRO(FindPthreads)
 		
 		FILE(WRITE ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeTmp/TestPthreads.c
 			"#include <pthread.h>\n"
+			"void* start_func(void* arg) { return 0; }\n"
 			"int main()\n"
 			"{\n"
 			"	pthread_t th;\n"
-			"	pthread_create(&th, 0, 0, 0);\n"
+			"	pthread_attr_t attr;\n"
+			"	pthread_create(&th, 0, start_func, 0);\n"
 			"	pthread_join(th, 0);\n"
-			"	pthread_attr_init(0);\n"
+			"	pthread_attr_init(&attr);\n"
 			"	pthread_cleanup_push(0, 0);\n"
 			"	pthread_cleanup_pop(0);\n"
 			"   return 0;\n"
@@ -77,6 +79,7 @@ MACRO(FindPthreads)
 			CMAKE_FLAGS "-DLINK_LIBRARIES:STRING=${_libs}"
 			COMPILE_DEFINITIONS "${_cflags}"
 			OUTPUT_VARIABLE _out
+			NO_CACHE
 		)
 		IF(PTHREADS_FOUND)
 			MESSAGE(STATUS "Checking pthreads with CFLAGS=\"${_cflags}\" and LIBS=\"${_libs}\" -- yes")


### PR DESCRIPTION
When attempting to build the project on Ubuntu 24.04, some adjustments to the build system (cmake) were required to succeed. I like to contribute them back and I suppose, splitting them up into smaller chunk makes them easier to discuss and adjust, if needed.

Here, libpthread could not be found because of the build errors of a more strict compiler, I guess (or the API changed).