### PR TITLE
[build] cmake: fix logic to set extern target also for dependencies found in system (non-Windows)

### DIFF
--- a/cmake/extern/boost.cmake
+++ b/cmake/extern/boost.cmake
@@ -31,77 +31,77 @@ else() # Local static build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
-	if(Boost_FOUND)
+if(Boost_FOUND)
 
-		add_definitions(-DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
-		
-		message(STATUS "Found Boost in ${Boost_DIR}:\n"
-							"         ${Boost_LIBRARIES}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(boost-extern DEPENDS Boost::test_exec_monitor Boost::unit_test_framework)
+	add_definitions(-DBOOST_MULTI_INDEX_DISABLE_SERIALIZATION)
 
-	else()	# Boost has not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
-		
-		set(BOOST_64BIT_FLAGS "")
-		if(CMAKE_SIZEOF_VOID_P EQUAL 8)
-			list(APPEND BOOST_64BIT_FLAGS "address-model=64")
-		endif()
-		
-		set(BOOST_TOOLSET msvc)	# Assume MSVC
-		set(BOOST_BOOTSTRAP "bootstrap")
+	message(STATUS "Found Boost in ${Boost_DIR}:\n"
+	               "         ${Boost_LIBRARIES}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(boost-extern DEPENDS Boost::test_exec_monitor Boost::unit_test_framework)
 
-		if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
-			 CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
-			set(BOOST_TOOLSET clang)
-		elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-			set(BOOST_TOOLSET gcc)
-		endif()	# MSVC is assumed and set above
-		
-		if(UNIX)
-			set(BOOST_BOOTSTRAP "./bootstrap.sh")
-		endif()
-		
-		set(BOOST_STATIC_RUNTIME)
-		if(NOT BUILD_SHARED_LIBS AND MINGW)
-			set(BOOST_STATIC_RUNTIME runtime-link=static)
-		endif()
-		
-		set(BOOST_MSVC_SHARED)
-		if(MSVC AND BUILD_SHARED_LIBS)
-		 set(BOOST_MSVC_SHARED variant=debug)
-		endif()
-		
-		ExternalProject_Add(
-			boost-extern
-			PREFIX ${EXTERN}
-			URL https://archives.boost.io/release/1.86.0/source/boost_1_86_0.7z
-			URL_HASH SHA256=413ee9d5754d0ac5994a3bf70c3b5606b10f33824fdd56cf04d425f2fc6bb8ce
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			CONFIGURE_COMMAND ""
-			BUILD_COMMAND ""  # All steps are done below because of working directory
-			INSTALL_COMMAND ""
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
-		)
-				
-		## Consider switching to an in source tree build. This below is tedious.
-		# Boost needs the cwd to be its source dir but ExernelProject_Add() uses
-		# <BINARY_DIR>. For out of source tree builds, we have to add extra steps.
-		ExternalProject_Add_Step(boost-extern bootstrap
-			DEPENDEES configure
-			DEPENDERS build
-			COMMAND ${BOOST_BOOTSTRAP} ${BOOST_TOOLSET}
-			WORKING_DIRECTORY <SOURCE_DIR>
-		)
-		
-		ExternalProject_Add_Step(boost-extern b2
-			DEPENDEES bootstrap
-			DEPENDERS install
-			COMMAND ./b2 --with-test toolset=${BOOST_TOOLSET} threading=multi link=static ${BOOST_STATIC_RUNTIME} variant=release ${BOOST_MSVC_SHARED} ${BOOST_64BIT_FLAGS} --layout=tagged --build-dir=<BINARY_DIR> --stagedir=${EXTERN}
-			WORKING_DIRECTORY <SOURCE_DIR>
-		)
+else()	# Boost has not been built yet. Configure for build.
 
+	set(HAVE_DEPENDENCIES FALSE)
+
+	set(BOOST_64BIT_FLAGS "")
+	if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+		list(APPEND BOOST_64BIT_FLAGS "address-model=64")
 	endif()
+
+	set(BOOST_TOOLSET msvc)	# Assume MSVC
+	set(BOOST_BOOTSTRAP "bootstrap")
+
+	if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR
+		 CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
+		set(BOOST_TOOLSET clang)
+	elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+		set(BOOST_TOOLSET gcc)
+	endif()	# MSVC is assumed and set above
+
+	if(UNIX)
+		set(BOOST_BOOTSTRAP "./bootstrap.sh")
+	endif()
+
+	set(BOOST_STATIC_RUNTIME)
+	if(NOT BUILD_SHARED_LIBS AND MINGW)
+		set(BOOST_STATIC_RUNTIME runtime-link=static)
+	endif()
+
+	set(BOOST_MSVC_SHARED)
+	if(MSVC AND BUILD_SHARED_LIBS)
+	 set(BOOST_MSVC_SHARED variant=debug)
+	endif()
+
+	ExternalProject_Add(
+		boost-extern
+		PREFIX ${EXTERN}
+		URL https://archives.boost.io/release/1.86.0/source/boost_1_86_0.7z
+		URL_HASH SHA256=413ee9d5754d0ac5994a3bf70c3b5606b10f33824fdd56cf04d425f2fc6bb8ce
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		CONFIGURE_COMMAND ""
+		BUILD_COMMAND ""  # All steps are done below because of working directory
+		INSTALL_COMMAND ""
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	)
+
+	## Consider switching to an in source tree build. This below is tedious.
+	# Boost needs the cwd to be its source dir but ExernelProject_Add() uses
+	# <BINARY_DIR>. For out of source tree builds, we have to add extra steps.
+	ExternalProject_Add_Step(boost-extern bootstrap
+		DEPENDEES configure
+		DEPENDERS build
+		COMMAND ${BOOST_BOOTSTRAP} ${BOOST_TOOLSET}
+		WORKING_DIRECTORY <SOURCE_DIR>
+	)
+
+	ExternalProject_Add_Step(boost-extern b2
+		DEPENDEES bootstrap
+		DEPENDERS install
+		COMMAND ./b2 --with-test toolset=${BOOST_TOOLSET} threading=multi link=static ${BOOST_STATIC_RUNTIME} variant=release ${BOOST_MSVC_SHARED} ${BOOST_64BIT_FLAGS} --layout=tagged --build-dir=<BINARY_DIR> --stagedir=${EXTERN}
+		WORKING_DIRECTORY <SOURCE_DIR>
+	)
+
 endif()

--- a/cmake/extern/freetype.cmake
+++ b/cmake/extern/freetype.cmake
@@ -14,39 +14,39 @@ else() # Local build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
-	if(Freetype_FOUND)
+if(Freetype_FOUND)
 
-		message(STATUS "Found Freetype in ${Freetype_DIR}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(freetype-extern DEPENDS Freetype::Freetype)
+	message(STATUS "Found Freetype in ${Freetype_DIR}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(freetype-extern DEPENDS Freetype::Freetype)
 
-	else()	# Freetype has not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
+else()	# Freetype has not been built yet. Configure for build.
 
-		ExternalProject_Add(
-			freetype-extern
-			URL https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
-			URL_HASH SHA256=0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			PREFIX ${EXTERN}
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-				-DFT_DISABLE_BZIP2=TRUE
-				-DFT_DISABLE_BROTLI=TRUE
-				-DFT_DISABLE_HARFBUZZ=TRUE
-				-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
-				-DBUILD_SHARED_LIBS=${SHARED_BOOL}
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
-			DEPENDS zlib-extern png-extern
-		)
+	set(HAVE_DEPENDENCIES FALSE)
 
-	endif()
+	ExternalProject_Add(
+		freetype-extern
+		URL https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.xz
+		URL_HASH SHA256=0550350666d427c74daeb85d5ac7bb353acba5f76956395995311a9c6f063289
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		PREFIX ${EXTERN}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+			-DFT_DISABLE_BZIP2=TRUE
+			-DFT_DISABLE_BROTLI=TRUE
+			-DFT_DISABLE_HARFBUZZ=TRUE
+			-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
+			-DBUILD_SHARED_LIBS=${SHARED_BOOL}
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+		DEPENDS zlib-extern png-extern
+	)
+
 endif()

--- a/cmake/extern/lzma.cmake
+++ b/cmake/extern/lzma.cmake
@@ -14,43 +14,43 @@ else() # Local build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
-	if(LibLZMA_FOUND)
+if(LibLZMA_FOUND)
 
-		# Use target liblzma::liblzma
-		# Fix static linking definition
-		if(NOT BUILD_SHARED_LIBS)
-		 	set_target_properties(liblzma::liblzma PROPERTIES
-		 		INTERFACE_COMPILE_DEFINITIONS LZMA_API_STATIC
-			)
-		endif()
-
-		message(STATUS "Found LibLZMA in ${LibLZMA_DIR}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(lzma-extern DEPENDS liblzma::liblzma)
-
-	else()	# LibLZMA has not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
-		
-		ExternalProject_Add(
-			lzma-extern
-			URL https://github.com/tukaani-project/xz/releases/download/v5.6.2/xz-5.6.2.tar.xz
-			URL_HASH SHA256=a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			PREFIX ${EXTERN}
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-				-DENABLE_NLS=OFF
-				-DBUILD_SHARED_LIBS=${SHARED_BOOL}
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	# Use target liblzma::liblzma
+	# Fix static linking definition
+	if(NOT BUILD_SHARED_LIBS)
+		set_target_properties(liblzma::liblzma PROPERTIES
+			INTERFACE_COMPILE_DEFINITIONS LZMA_API_STATIC
 		)
-	
 	endif()
+
+	message(STATUS "Found LibLZMA in ${LibLZMA_DIR}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(lzma-extern DEPENDS liblzma::liblzma)
+
+else()	# LibLZMA has not been built yet. Configure for build.
+
+	set(HAVE_DEPENDENCIES FALSE)
+
+	ExternalProject_Add(
+		lzma-extern
+		URL https://github.com/tukaani-project/xz/releases/download/v5.6.2/xz-5.6.2.tar.xz
+		URL_HASH SHA256=a9db3bb3d64e248a0fae963f8fb6ba851a26ba1822e504dc0efd18a80c626caf
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		PREFIX ${EXTERN}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+			-DENABLE_NLS=OFF
+			-DBUILD_SHARED_LIBS=${SHARED_BOOL}
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	)
+
 endif()

--- a/cmake/extern/openssl.cmake
+++ b/cmake/extern/openssl.cmake
@@ -15,89 +15,89 @@ else() # Local build, only static
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
-	if(OpenSSL_FOUND)
+if(OpenSSL_FOUND)
 
-		message(STATUS "Found OpenSSL in ${OpenSSL_DIR}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(openssl-extern DEPENDS OpenSSL::Crypto OpenSSL::SSL)
+	message(STATUS "Found OpenSSL in ${OpenSSL_DIR}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(openssl-extern DEPENDS OpenSSL::Crypto OpenSSL::SSL)
 
-	else()	# OpenSSLhas not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
+else()	# OpenSSLhas not been built yet. Configure for build.
 
-		# Find Perl if Windows and not in MSYS
-		if(MSVC)
-			get_filename_component(
-				ActivePerl_CurrentVersion
-				"[HKEY_LOCAL_MACHINE\\SOFTWARE\\ActiveState\\ActivePerl;CurrentVersion]"
-				NAME)
-			set(ST_PERL_PATH
-				${ST_PERL_PATH}
-				"C:/Perl/bin"
-				"C:/Strawberry/perl/bin"
-				[HKEY_LOCAL_MACHINE\\SOFTWARE\\ActiveState\\ActivePerl\\${ActivePerl_CurrentVersion}]/bin
-			)
-			
-			find_program(PERL_EXECUTABLE
-				NAMES perl
-				PATHS ${ST_PERL_PATH}
-				REQUIRED
-			)
-		else()
-			set(PERL_EXECUTABLE perl)
-		endif()
-		
-		
-		# Find number of available threads for multithreaded compilation of QT5
-		include(ProcessorCount)
-		ProcessorCount(N)
-		math(EXPR THREADS "${N} - 1")
-		if(NOT N EQUAL 0)
-			set(JX "-j${THREADS}")
-		endif()
-		
-		set(OPENSSL_SOURCE_DIR ${EXTERN}/src/openssl-extern)
-		if(MSVC)
-			set(OPENSSL_CONFIGURE_COMMAND ${PERL_EXECUTABLE} ${OPENSSL_SOURCE_DIR}/Configure VC-WIN64A)
-			set(OPENSSL_BUILD_COMMAND nmake /C /S)
-			set(OPENSSL_INSTALL_COMMAND nmake install)
-		elseif(MINGW)
-			set(OPENSSL_CONFIGURE_COMMAND perl ${OPENSSL_SOURCE_DIR}/Configure mingw64)
-			set(OPENSSL_BUILD_COMMAND mingw32-make ${JX})
-			set(OPENSSL_INSTALL_COMMAND mingw32-make install)
-		else()
-			set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure)
-			set(OPENSSL_BUILD_COMMAND make ${JX})
-			set(OPENSSL_INSTALL_COMMAND make install)
-		endif()
+	set(HAVE_DEPENDENCIES FALSE)
 
-		set(ssl-static)
-		if(NOT BUILD_SHARED_LIBS)
-			set(ssl-static no-shared)
-		endif()
-
-		ExternalProject_Add(
-			openssl-extern
-			PREFIX ${EXTERN}
-			URL https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz
-			URL_HASH SHA256=2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			CONFIGURE_COMMAND
-				${OPENSSL_CONFIGURE_COMMAND}
-				--prefix=<INSTALL_DIR>
-				--openssldir=<INSTALL_DIR>/SSL
-				--libdir=lib
-				--release
-				no-apps
-				${ssl-static}
-				no-tests
-				no-docs
-			BUILD_COMMAND ${OPENSSL_BUILD_COMMAND}
-			TEST_COMMAND ""
-			INSTALL_COMMAND ${OPENSSL_INSTALL_COMMAND}
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	# Find Perl if Windows and not in MSYS
+	if(MSVC)
+		get_filename_component(
+			ActivePerl_CurrentVersion
+			"[HKEY_LOCAL_MACHINE\\SOFTWARE\\ActiveState\\ActivePerl;CurrentVersion]"
+			NAME)
+		set(ST_PERL_PATH
+			${ST_PERL_PATH}
+			"C:/Perl/bin"
+			"C:/Strawberry/perl/bin"
+			[HKEY_LOCAL_MACHINE\\SOFTWARE\\ActiveState\\ActivePerl\\${ActivePerl_CurrentVersion}]/bin
 		)
 
+		find_program(PERL_EXECUTABLE
+			NAMES perl
+			PATHS ${ST_PERL_PATH}
+			REQUIRED
+		)
+	else()
+		set(PERL_EXECUTABLE perl)
 	endif()
+
+
+	# Find number of available threads for multithreaded compilation of QT5
+	include(ProcessorCount)
+	ProcessorCount(N)
+	math(EXPR THREADS "${N} - 1")
+	if(NOT N EQUAL 0)
+		set(JX "-j${THREADS}")
+	endif()
+
+	set(OPENSSL_SOURCE_DIR ${EXTERN}/src/openssl-extern)
+	if(MSVC)
+		set(OPENSSL_CONFIGURE_COMMAND ${PERL_EXECUTABLE} ${OPENSSL_SOURCE_DIR}/Configure VC-WIN64A)
+		set(OPENSSL_BUILD_COMMAND nmake /C /S)
+		set(OPENSSL_INSTALL_COMMAND nmake install)
+	elseif(MINGW)
+		set(OPENSSL_CONFIGURE_COMMAND perl ${OPENSSL_SOURCE_DIR}/Configure mingw64)
+		set(OPENSSL_BUILD_COMMAND mingw32-make ${JX})
+		set(OPENSSL_INSTALL_COMMAND mingw32-make install)
+	else()
+		set(OPENSSL_CONFIGURE_COMMAND ${OPENSSL_SOURCE_DIR}/Configure)
+		set(OPENSSL_BUILD_COMMAND make ${JX})
+		set(OPENSSL_INSTALL_COMMAND make install)
+	endif()
+
+	set(ssl-static)
+	if(NOT BUILD_SHARED_LIBS)
+		set(ssl-static no-shared)
+	endif()
+
+	ExternalProject_Add(
+		openssl-extern
+		PREFIX ${EXTERN}
+		URL https://github.com/openssl/openssl/releases/download/openssl-3.3.2/openssl-3.3.2.tar.gz
+		URL_HASH SHA256=2e8a40b01979afe8be0bbfb3de5dc1c6709fedb46d6c89c10da114ab5fc3d281
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		CONFIGURE_COMMAND
+			${OPENSSL_CONFIGURE_COMMAND}
+			--prefix=<INSTALL_DIR>
+			--openssldir=<INSTALL_DIR>/SSL
+			--libdir=lib
+			--release
+			no-apps
+			${ssl-static}
+			no-tests
+			no-docs
+		BUILD_COMMAND ${OPENSSL_BUILD_COMMAND}
+		TEST_COMMAND ""
+		INSTALL_COMMAND ${OPENSSL_INSTALL_COMMAND}
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	)
+
 endif()

--- a/cmake/extern/png.cmake
+++ b/cmake/extern/png.cmake
@@ -14,6 +14,7 @@ else() # Local build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
 	if(png_FOUND)
 
@@ -21,44 +22,43 @@ else() # Local build
 		# Needed for dependency satisfaction after external project has been built
 		add_custom_target(png-extern DEPENDS PNG::PNG)
 
-	else()	# png has not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
+else()	# png has not been built yet. Configure for build.
 
-		ExternalProject_Add(
-			png-extern
-			PREFIX ${EXTERN}
-			URL https://download.sourceforge.net/libpng/libpng-1.6.44.tar.xz
-			URL_HASH SHA256=60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-				-DCMAKE_MODULE_PATH=
-				-DZLIB_ROOT=${EXTERN}
-				-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
-				-DSKIP_INSTALL_EXECUTABLES=ON
-				-DSKIP_INSTALL_PROGRAMS=ON
-				-DPNG_TOOLS=OFF
-				-DPNG_TESTS=OFF
-				-DPNG_STATIC=${STATIC_BOOL}
-				-DPNG_SHARED=${SHARED_BOOL}
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
-			DEPENDS zlib-extern lzma-extern
-		)
+	set(HAVE_DEPENDENCIES FALSE)
 
-		# Hardlink static lib to shared name so qt5 can pick up our png under msvc
-		# if(NOT BUILD_SHARED_LIBS AND MSVC)
-		# 	ExternalProject_Add_Step(
-		# 		png-extern qt5-compat-install
-		# 		DEPENDEES install
-		# 		COMMAND ${CMAKE_COMMAND} -E create_hardlink ${EXTERN_LIB_DIR}/${ST_PNG_STATIC} ${EXTERN_LIB_DIR}/${ST_PNG_IMPLIB}
-		# 	)
-		# endif()
-	endif()
+	ExternalProject_Add(
+		png-extern
+		PREFIX ${EXTERN}
+		URL https://download.sourceforge.net/libpng/libpng-1.6.44.tar.xz
+		URL_HASH SHA256=60c4da1d5b7f0aa8d158da48e8f8afa9773c1c8baa5d21974df61f1886b8ce8e
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+			-DCMAKE_MODULE_PATH=
+			-DZLIB_ROOT=${EXTERN}
+			-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
+			-DSKIP_INSTALL_EXECUTABLES=ON
+			-DSKIP_INSTALL_PROGRAMS=ON
+			-DPNG_TOOLS=OFF
+			-DPNG_TESTS=OFF
+			-DPNG_STATIC=${STATIC_BOOL}
+			-DPNG_SHARED=${SHARED_BOOL}
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+		DEPENDS zlib-extern lzma-extern
+	)
+
+	# Hardlink static lib to shared name so qt5 can pick up our png under msvc
+	# if(NOT BUILD_SHARED_LIBS AND MSVC)
+	# 	ExternalProject_Add_Step(
+	# 		png-extern qt5-compat-install
+	# 		DEPENDEES install
+	# 		COMMAND ${CMAKE_COMMAND} -E create_hardlink ${EXTERN_LIB_DIR}/${ST_PNG_STATIC} ${EXTERN_LIB_DIR}/${ST_PNG_IMPLIB}
+	# 	)
+	# endif()
 endif()

--- a/cmake/extern/podofo.cmake
+++ b/cmake/extern/podofo.cmake
@@ -17,67 +17,67 @@ else() # Local build
 		QUIET
 	)
 
-	if(podofo_FOUND)
-		
-		if(BUILD_SHARED_LIBS)
-			add_library(podofo ALIAS podofo_shared)
-			target_link_libraries(podofo_shared INTERFACE OpenSSL::Crypto Freetype::Freetype LibXml2::LibXml2 ZLIB::ZLIB)
-		else()
-			add_library(podofo ALIAS podofo_static)
-			set_target_properties(podofo_static podofo_private PROPERTIES
-				INTERFACE_INCLUDE_DIRECTORIES ${EXTERN_INC_DIR}/podofo
-				INTERFACE_COMPILE_DEFINITIONS PODOFO_STATIC
-			)
-			# Fix podofo not linking against OpenSSL::Crypto
-			target_link_libraries(podofo_static INTERFACE OpenSSL::Crypto Freetype::Freetype LibXml2::LibXml2 ZLIB::ZLIB)
-		endif()
-
-	
-		message(STATUS "Found PoDoFo in ${podofo_DIR}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(podofo-extern DEPENDS podofo)
-
-
-	else() # PoDoFo has not been built yet. Configure for build.
-	
-		set(HAVE_DEPENDENCIES FALSE)
-
-		set(DISABLE_FIND_PACKAGE)
-		if(WIN32)
-			set(DISABLE_FIND_PACKAGE -DCMAKE_DISABLE_FIND_PACKAGE_Libidn=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_Fontconfig=TRUE)
-		else()
-			set(DISABLE_FIND_PACKAGE -DCMAKE_DISABLE_FIND_PACKAGE_Libidn=TRUE)
-		endif()
-
-		if(NOT BUILD_SHARED_LIBS)
-			set(STATIC_XML LIBXML_STATIC)
-		endif()
-
-		ExternalProject_Add(
-			podofo-extern
-			PREFIX ${EXTERN}
-			# URL https://github.com/podofo/podofo/archive/refs/tags/0.10.4.tar.gz
-			# URL_HASH SHA256=6b1b13cdfb2ba5e8bbc549df507023dd4873bc946211bc6942183b8496986904
-			GIT_REPOSITORY https://github.com/podofo/podofo.git
-			GIT_TAG 1.0.0-beta
-			GIT_SHALLOW TRUE
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/podofo/CMakeLists.txt <SOURCE_DIR>
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DPODOFO_BUILD_LIB_ONLY=ON
-				-DPODOFO_BUILD_STATIC=${STATIC_BOOL}
-				-DCOMPILE_DEFINITIONS=${STATIC_XML}
-				${DISABLE_FIND_PACKAGE}
-				-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config RelWithDebInfo
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config RelWithDebInfo
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
-			DEPENDS zlib-extern png-extern tiff-extern freetype-extern xml2-extern lzma-extern openssl-extern
+	if(BUILD_SHARED_LIBS)
+		add_library(podofo ALIAS podofo_shared)
+		target_link_libraries(podofo_shared INTERFACE OpenSSL::Crypto Freetype::Freetype LibXml2::LibXml2 ZLIB::ZLIB)
+	else()
+		add_library(podofo ALIAS podofo_static)
+		set_target_properties(podofo_static podofo_private PROPERTIES
+			INTERFACE_INCLUDE_DIRECTORIES ${EXTERN_INC_DIR}/podofo
+			INTERFACE_COMPILE_DEFINITIONS PODOFO_STATIC
 		)
-
+		# Fix podofo not linking against OpenSSL::Crypto
+		target_link_libraries(podofo_static INTERFACE OpenSSL::Crypto Freetype::Freetype LibXml2::LibXml2 ZLIB::ZLIB)
 	endif()
+
+endif()
+
+if(podofo_FOUND)
+
+	message(STATUS "Found PoDoFo in ${podofo_DIR}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(podofo-extern DEPENDS podofo)
+
+
+else() # PoDoFo has not been built yet. Configure for build.
+
+	set(HAVE_DEPENDENCIES FALSE)
+
+	set(DISABLE_FIND_PACKAGE)
+	if(WIN32)
+		set(DISABLE_FIND_PACKAGE -DCMAKE_DISABLE_FIND_PACKAGE_Libidn=TRUE -DCMAKE_DISABLE_FIND_PACKAGE_Fontconfig=TRUE)
+	else()
+		set(DISABLE_FIND_PACKAGE -DCMAKE_DISABLE_FIND_PACKAGE_Libidn=TRUE)
+	endif()
+
+	if(NOT BUILD_SHARED_LIBS)
+		set(STATIC_XML LIBXML_STATIC)
+	endif()
+
+	ExternalProject_Add(
+		podofo-extern
+		PREFIX ${EXTERN}
+		# URL https://github.com/podofo/podofo/archive/refs/tags/0.10.4.tar.gz
+		# URL_HASH SHA256=6b1b13cdfb2ba5e8bbc549df507023dd4873bc946211bc6942183b8496986904
+		GIT_REPOSITORY https://github.com/podofo/podofo.git
+		GIT_TAG 1.0.0-beta
+		GIT_SHALLOW TRUE
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/podofo/CMakeLists.txt <SOURCE_DIR>
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DPODOFO_BUILD_LIB_ONLY=ON
+			-DPODOFO_BUILD_STATIC=${STATIC_BOOL}
+			-DCOMPILE_DEFINITIONS=${STATIC_XML}
+			${DISABLE_FIND_PACKAGE}
+			-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config RelWithDebInfo
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config RelWithDebInfo
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+		DEPENDS zlib-extern png-extern tiff-extern freetype-extern xml2-extern lzma-extern openssl-extern
+	)
+
 endif()

--- a/cmake/extern/tiff.cmake
+++ b/cmake/extern/tiff.cmake
@@ -14,6 +14,7 @@ else() # Local build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
 	if(tiff_FOUND)
 
@@ -26,53 +27,52 @@ else() # Local build
 		# Needed for dependency satisfaction after external project has been built
 		add_custom_target(tiff-extern DEPENDS TIFF::tiff)
 
-	else()	# tiff has not been built yet. Configure for build.
+else()	# tiff has not been built yet. Configure for build.
+
+	set(HAVE_DEPENDENCIES FALSE)
+
+	ExternalProject_Add(
+		tiff-extern
+		URL https://download.osgeo.org/libtiff/tiff-4.7.0.tar.xz
+		URL_HASH SHA256=273a0a73b1f0bed640afee4a5df0337357ced5b53d3d5d1c405b936501f71017
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		PREFIX ${EXTERN}
+		# Fix MSVC static linking ot lzma
+		PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/tiff/libtiff/CMakeLists.txt <SOURCE_DIR>/libtiff
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+			-DBUILD_SHARED_LIBS=${SHARED_BOOL}
+			-Dwebp=OFF
+			-Dlzma=ON
+			-Dzstd=ON
+			-Dtiff-tools=OFF
+			-Dtiff-tests=OFF
+			-Dtiff-contrib=OFF
+			-Dtiff-docs=OFF
+			-DCMAKE_DISABLE_FIND_PACKAGE_GLUT=TRUE
+			-DCMAKE_DISABLE_FIND_PACKAGE_Deflate=TRUE
+			-DCMAKE_DISABLE_FIND_PACKAGE_JBIG=TRUE
+			-DCMAKE_DISABLE_FIND_PACKAGE_LERC=TRUE
+			-DCMAKE_MODULE_PATH=
+			-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+		DEPENDS zlib-extern jpeg-extern zstd-extern lzma-extern
+	)
+
 	
-		set(HAVE_DEPENDENCIES FALSE)
-
-		ExternalProject_Add(
-			tiff-extern
-			URL https://download.osgeo.org/libtiff/tiff-4.7.0.tar.xz
-			URL_HASH SHA256=273a0a73b1f0bed640afee4a5df0337357ced5b53d3d5d1c405b936501f71017
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			PREFIX ${EXTERN}
-			# Fix MSVC static linking ot lzma
-			PATCH_COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/tiff/libtiff/CMakeLists.txt <SOURCE_DIR>/libtiff
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-				-DBUILD_SHARED_LIBS=${SHARED_BOOL}
-				-Dwebp=OFF
-				-Dlzma=ON
-				-Dzstd=ON
-				-Dtiff-tools=OFF
-				-Dtiff-tests=OFF
-				-Dtiff-contrib=OFF
-				-Dtiff-docs=OFF
-				-DCMAKE_DISABLE_FIND_PACKAGE_GLUT=TRUE
-				-DCMAKE_DISABLE_FIND_PACKAGE_Deflate=TRUE
-				-DCMAKE_DISABLE_FIND_PACKAGE_JBIG=TRUE
-				-DCMAKE_DISABLE_FIND_PACKAGE_LERC=TRUE
-				-DCMAKE_MODULE_PATH=
-				-DZLIB_USE_STATIC_LIBS=${ZLIB_USE_STATIC_LIBS}
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
-			DEPENDS zlib-extern jpeg-extern zstd-extern lzma-extern
+	# <LINK_ONLY> dependencies cannot be found in external projects,
+	# if they don't find_package() for them. Fix it.
+	if(NOT BUILD_SHARED_LIBS)
+		ExternalProject_Add_Step(
+			tiff-extern after-install-patch
+			DEPENDEES install
+			COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/tiff/TiffTargets.cmake ${EXTERN}/lib/cmake/tiff/
 		)
-
-		
-		# <LINK_ONLY> dependencies cannot be found in external projects,
-		# if they don't find_package() for them. Fix it.
-		if(NOT BUILD_SHARED_LIBS)
-			ExternalProject_Add_Step(
-				tiff-extern after-install-patch
-				DEPENDEES install
-				COMMAND ${CMAKE_COMMAND} -E copy ${EXTERN_PATCH_DIR}/tiff/TiffTargets.cmake ${EXTERN}/lib/cmake/tiff/
-			)
-		endif()
 	endif()
 endif()

--- a/cmake/extern/xml2.cmake
+++ b/cmake/extern/xml2.cmake
@@ -15,50 +15,50 @@ else() # Local build
 		HINTS ${EXTERN}
 		QUIET
 	)
+endif()
 
-	if(LibXml2_FOUND)
+if(LibXml2_FOUND)
 
-		# Use target LibXml2::LibXml2
+	# Use target LibXml2::LibXml2
 
-		message(STATUS "Found LibXml2 in ${LibXml2_DIR}")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(xml2-extern DEPENDS LibXml2::LibXml2)
+	message(STATUS "Found LibXml2 in ${LibXml2_DIR}")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(xml2-extern DEPENDS LibXml2::LibXml2)
 
-	else()	# LibXml2 has not been built yet. Configure for build.
+else()	# LibXml2 has not been built yet. Configure for build.
+
+	set(HAVE_DEPENDENCIES FALSE)
+
+	ExternalProject_Add(
+		xml2-extern
+		URL https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.tar.xz
+		URL_HASH SHA256=65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650
+		PREFIX ${EXTERN}
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+			-DBUILD_SHARED_LIBS=${SHARED_BOOL}
+			-DLIBXML2_WITH_ICONV=OFF
+			-DLIBXML2_WITH_PROGRAMS=OFF
+			-DLIBXML2_WITH_PYTHON=OFF
+			-DLIBXML2_WITH_TESTS=OFF
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	)
 	
-		set(HAVE_DEPENDENCIES FALSE)
-
-		ExternalProject_Add(
-			xml2-extern
-			URL https://download.gnome.org/sources/libxml2/2.13/libxml2-2.13.4.tar.xz
-			URL_HASH SHA256=65d042e1c8010243e617efb02afda20b85c2160acdbfbcb5b26b80cec6515650
-			PREFIX ${EXTERN}
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-				-DBUILD_SHARED_LIBS=${SHARED_BOOL}
-				-DLIBXML2_WITH_ICONV=OFF
-				-DLIBXML2_WITH_PROGRAMS=OFF
-				-DLIBXML2_WITH_PYTHON=OFF
-				-DLIBXML2_WITH_TESTS=OFF
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	# podofo under msvc can't find libxml2s.lib; create hardlink from static lib to shared name
+	if(NOT BUILD_SHARED_LIBS AND MSVC)
+		ExternalProject_Add_Step(
+			xml2-extern podofo-compat-install
+			DEPENDEES install
+			# create a hardlink with the name of the shared implib
+			COMMAND ${CMAKE_COMMAND} -E create_hardlink ${EXTERN_LIB_DIR}/libxml2s.lib ${EXTERN_LIB_DIR}/libxml2.lib
 		)
-		
-		# podofo under msvc can't find libxml2s.lib; create hardlink from static lib to shared name
-		if(NOT BUILD_SHARED_LIBS AND MSVC)
-			ExternalProject_Add_Step(
-				xml2-extern podofo-compat-install
-				DEPENDEES install
-				# create a hardlink with the name of the shared implib
-				COMMAND ${CMAKE_COMMAND} -E create_hardlink ${EXTERN_LIB_DIR}/libxml2s.lib ${EXTERN_LIB_DIR}/libxml2.lib
-			)
-		endif()
-
 	endif()
+
 endif()

--- a/cmake/extern/zlib.cmake
+++ b/cmake/extern/zlib.cmake
@@ -16,44 +16,44 @@ else() # Local build
 	endif()
 
 	# Zlib has no cmake target files so we need to use basic find_package mode
-	find_package(ZLIB	QUIET)
+	find_package(ZLIB QUIET)
+endif()
 
-	if(ZLIB_FOUND)
+if(ZLIB_FOUND)
 
-		message(STATUS "Found zlib: ${ZLIB_LIBRARIES} (version ${ZLIB_VERSION})")
-		# Needed for dependency satisfaction after external project has been built
-		add_custom_target(zlib-extern DEPENDS ZLIB::ZLIB)
+	message(STATUS "Found zlib: ${ZLIB_LIBRARIES} (version ${ZLIB_VERSION})")
+	# Needed for dependency satisfaction after external project has been built
+	add_custom_target(zlib-extern DEPENDS ZLIB::ZLIB)
 
-	else()	# zlib has not been built yet. Configure for build.
+else()	# zlib has not been built yet. Configure for build.
+
+	set(HAVE_DEPENDENCIES FALSE)
+
+	ExternalProject_Add(
+		zlib-extern
+		PREFIX ${EXTERN}
+		URL https://www.zlib.net/zlib-1.3.1.tar.xz
+		URL_HASH SHA256=38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32
+		DOWNLOAD_DIR ${DOWNLOAD_DIR}
+		CMAKE_ARGS
+			-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+			-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
+			-DCMAKE_BUILD_TYPE=Release
+		BUILD_COMMAND
+			${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
+		INSTALL_COMMAND
+			${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
+		UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	)
 	
-		set(HAVE_DEPENDENCIES FALSE)
-
-		ExternalProject_Add(
-			zlib-extern
-			PREFIX ${EXTERN}
-			URL https://www.zlib.net/zlib-1.3.1.tar.xz
-			URL_HASH SHA256=38ef96b8dfe510d42707d9c781877914792541133e1870841463bfa73f883e32
-			DOWNLOAD_DIR ${DOWNLOAD_DIR}
-			CMAKE_ARGS
-				-DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-				-DCMAKE_PREFIX_PATH=<INSTALL_DIR>
-				-DCMAKE_BUILD_TYPE=Release
-			BUILD_COMMAND
-				${CMAKE_COMMAND} --build <BINARY_DIR> --config Release
-			INSTALL_COMMAND
-				${CMAKE_COMMAND} --install <BINARY_DIR> --config Release
-			UPDATE_COMMAND ""  # Don't rebuild on main project recompilation
+	# zlib installs both shared and static libs. If building static,
+	# we need to remove the shared lib, so they don't get picked up by other packages
+	if(NOT BUILD_SHARED_LIBS AND MSVC)
+		ExternalProject_Add_Step(
+			zlib-extern remove-shared
+			DEPENDEES install
+			COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERN_BIN_DIR}/zlib.dll
+			COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERN_LIB_DIR}/zlib.lib
 		)
-		
-		# zlib installs both shared and static libs. If building static,
-		# we need to remove the shared lib, so they don't get picked up by other packages
-		if(NOT BUILD_SHARED_LIBS AND MSVC)
-			ExternalProject_Add_Step(
-				zlib-extern remove-shared
-				DEPENDEES install
-				COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERN_BIN_DIR}/zlib.dll
-				COMMAND ${CMAKE_COMMAND} -E rm -f ${EXTERN_LIB_DIR}/zlib.lib
-			)
-		endif()
 	endif()
 endif()


### PR DESCRIPTION
When attempting to build the project on Ubuntu 24.04, some adjustments to the build system (cmake) were required to succeed. I like to contribute them back and I suppose, splitting them up into smaller chunk makes them easier to discuss and adjust, if needed.