### PR TITLE
[build] cmake: allow eigen3 lib from system-wide install

### DIFF
--- a/cmake/extern/eigen3.cmake
+++ b/cmake/extern/eigen3.cmake
@@ -3,7 +3,7 @@
 
 # Try searching for Eigen in system
 # This finds eigen in other local build trees, but sets the include path wrong for some reason.
-# find_package(Eigen3 NO_MODULE GLOBAL QUIET)
+find_package(Eigen3 NO_MODULE GLOBAL QUIET)
 
 if(TARGET Eigen3::Eigen)
 


### PR DESCRIPTION
When attempting to build the project on Ubuntu 24.04, some adjustments to the build system (cmake) were required to succeed. I like to contribute them back and I suppose, splitting them up into smaller chunk makes them easier to discuss and adjust, if needed.

Wasn't sure, how to fix this in a compatible manner, but it has to look for it in the system somehow ...