### PR TITLE
[build] cmake: lzma imported target alias as expected

### DIFF
--- a/cmake/extern/lzma.cmake
+++ b/cmake/extern/lzma.cmake
@@ -4,6 +4,7 @@
 if(NOT WIN32 AND BUILD_SHARED_LIBS)
 
 	find_package(LibLZMA)		# This only finds shared libs
+	add_library(liblzma::liblzma ALIAS LibLZMA::LibLZMA)
 	
 else() # Local build
 	


### PR DESCRIPTION
When attempting to build the project on Ubuntu 24.04, some adjustments to the build system (cmake) were required to succeed. I like to contribute them back and I suppose, splitting them up into smaller chunk makes them easier to discuss and adjust, if needed.

Spelling of target names is an issue, ie. needs to be the same on Windows and non-Win.